### PR TITLE
Change "edited" to "synchronize"

### DIFF
--- a/lib/pr_actions.rb
+++ b/lib/pr_actions.rb
@@ -1,5 +1,5 @@
 PR_ACTIONS = %w[
-  edited
+  synchronize
   opened
   reopened
 ].freeze


### PR DESCRIPTION
Turns out "edited" is just for changes to the title/description, "synchronize" is what's triggered when a PR commit is added/changed.